### PR TITLE
ignore directories correctly

### DIFF
--- a/plugin/gitignore.vim
+++ b/plugin/gitignore.vim
@@ -41,7 +41,7 @@ function s:WildignoreFromGitignore(...)
       if line =~ '^#' | con | endif
       if line == ''   | con | endif
       if line =~ '^!' | con | endif
-      if line =~ '/$' | let igstring .= "," . line . "*" | con | endif
+      if line =~ '/$' | let igstring .= ",*/" . line . "*" | con | endif
       let igstring .= "," . substitute(line, ' ', '\\ ', "g")
     endfor
     let execstring = "set wildignore+=".substitute(igstring, '^,', '', "g")


### PR DESCRIPTION
`set wildignore+=some_dir/*` does not affect `some_dir` directory. One should use `set wildignore+=*/some_dir/*`.